### PR TITLE
Add unit tests and enable to configure parameters from command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 __pycache__/
 /.vim
 /figs
-/data
+data/

--- a/aibes/model.py
+++ b/aibes/model.py
@@ -49,28 +49,28 @@ class GAIStaticAgent(Agent):
     """
     def __init__(self, lamb: float, k: NumberOfOptions, lr: float):
         self.__alpha = np.exp(2 * lamb)
-        self.__alpha_t: NDArray[1, float] = np.ones(k)
-        self.__beta_t: NDArray[1, float] = np.ones(k)
+        self._alpha_t: NDArray[1, float] = np.ones(k)
+        self._beta_t: NDArray[1, float] = np.ones(k)
         self.__lr = lr
         self.__k = k
 
     def update(self, reward: NDArray[1, Reward], action: NDArray[1, Action]):
-        self.__alpha_t += reward * action * self.__lr
-        self.__beta_t += (1 - reward) * action * self.__lr
+        self._alpha_t += reward * action * self.__lr
+        self._beta_t += (1 - reward) * action * self.__lr
 
     def predict(self) -> Tuple[NDArray[1, Prediction], NDArray[1, float]]:
-        nu_t = self.__alpha_t + self.__beta_t
-        mu_t = self.__alpha_t / nu_t
-        kl_div_a = -betaln(self.__alpha_t, self.__beta_t) \
-            + (self.__alpha_t - self.__alpha) * digamma(self.__alpha_t) \
-            + (self.__beta_t - 1) * digamma(self.__beta_t) \
+        nu_t = self._alpha_t + self._beta_t
+        mu_t = self._alpha_t / nu_t
+        kl_div_a = -betaln(self._alpha_t, self._beta_t) \
+            + (self._alpha_t - self.__alpha) * digamma(self._alpha_t) \
+            + (self._beta_t - 1) * digamma(self._beta_t) \
             + (self.__alpha + 1 - nu_t) * digamma(nu_t)
-        h_a = - mu_t * digamma(self.__alpha_t + 1) \
-            - (1 - mu_t) * digamma(self.__beta_t + 1) \
+        h_a = - mu_t * digamma(self._alpha_t + 1) \
+            - (1 - mu_t) * digamma(self._beta_t + 1) \
             + digamma(nu_t + 1)
         epistemic = \
-            mu_t * (-np.log(mu_t) + digamma(self.__alpha_t + 1) - digamma(nu_t + 1)) \
-            + (1 - mu_t) * (-np.log(1 - mu_t) + digamma(self.__beta_t + 1) - digamma(nu_t + 1))
+            mu_t * (-np.log(mu_t) + digamma(self._alpha_t + 1) - digamma(nu_t + 1)) \
+            + (1 - mu_t) * (-np.log(1 - mu_t) + digamma(self._beta_t + 1) - digamma(nu_t + 1))
         pragmatic = kl_div_a + h_a - epistemic
         return pragmatic, epistemic
 
@@ -87,11 +87,11 @@ class GAIStaticAgent(Agent):
 
     @property
     def alpha_t(self) -> NDArray[1, float]:
-        return self.__alpha_t
+        return self._alpha_t
 
     @property
     def beta_t(self) -> NDArray[1, float]:
-        return self.__beta_t
+        return self._beta_t
 
     @property
     def k(self) -> int:
@@ -106,28 +106,28 @@ class SAIStaticAgent(Agent):
     """
     def __init__(self, lamb: float, k: NumberOfOptions, lr: float):
         self.__lambda = lamb
-        self.__alpha_t: NDArray[1, float] = np.ones(k)
-        self.__beta_t: NDArray[1, float] = np.ones(k)
+        self._alpha_t: NDArray[1, float] = np.ones(k)
+        self._beta_t: NDArray[1, float] = np.ones(k)
         self.__lr = lr
         self.__k = k
 
     def update(self, reward: Reward, action: Action):
-        self.__alpha_t += reward * action * self.__lr
-        self.__beta_t += (1 - reward) * action * self.__lr
+        self._alpha_t += reward * action * self.__lr
+        self._beta_t += (1 - reward) * action * self.__lr
 
     def predict(self) -> Tuple[NDArray[1, Prediction], NDArray[1, Prediction]]:
-        nu_t = self.__alpha_t + self.__beta_t
-        mu_t = self.__alpha_t / nu_t
+        nu_t = self._alpha_t + self._beta_t
+        mu_t = self._alpha_t / nu_t
 
         kl_div_a = - self.__lambda * (2 * mu_t - 1) \
             + mu_t * np.log(mu_t) \
             + (1 - mu_t) * np.log(1 - mu_t)
-        h_a = - mu_t * digamma(self.__alpha_t + 1) \
-            - (1 - mu_t) * digamma(self.__beta_t + 1) \
+        h_a = - mu_t * digamma(self._alpha_t + 1) \
+            - (1 - mu_t) * digamma(self._beta_t + 1) \
             + digamma(nu_t + 1)
         epistemic = \
-            mu_t * (-np.log(mu_t) + digamma(self.__alpha_t + 1) - digamma(nu_t + 1)) \
-            + (1 - mu_t) * (-np.log(1 - mu_t) + digamma(self.__beta_t + 1) - digamma(nu_t + 1))
+            mu_t * (-np.log(mu_t) + digamma(self._alpha_t + 1) - digamma(nu_t + 1)) \
+            + (1 - mu_t) * (-np.log(1 - mu_t) + digamma(self._beta_t + 1) - digamma(nu_t + 1))
         pragmatic = kl_div_a + h_a - epistemic
         return pragmatic, epistemic
 
@@ -144,11 +144,11 @@ class SAIStaticAgent(Agent):
 
     @property
     def alpha_t(self) -> NDArray[1, float]:
-        return self.__alpha_t
+        return self._alpha_t
 
     @property
     def beta_t(self) -> NDArray[1, float]:
-        return self.__beta_t
+        return self._beta_t
 
     @property
     def k(self) -> int:
@@ -158,10 +158,10 @@ class SAIStaticAgent(Agent):
 class GAIDynamicAgent(Agent):
     def __init__(self, lamb: float, k: NumberOfOptions, lr: float):
         self.__alpha = np.exp(2 * lamb)
-        self.__alpha_t: NDArray[1, float] = np.ones(k)
-        self.__alpha_zero = self.__alpha_t.copy()
-        self.__beta_t: NDArray[1, float] = np.ones(k)
-        self.__beta_zero = self.__beta_t.copy()
+        self._alpha_t: NDArray[1, float] = np.ones(k)
+        self.__alpha_zero = self._alpha_t.copy()
+        self._beta_t: NDArray[1, float] = np.ones(k)
+        self.__beta_zero = self._beta_t.copy()
         self.__a = np.full(k, 0.5)
         self.__b = np.full(k, 20.)
         self.__omega = np.zeros(k)
@@ -170,35 +170,35 @@ class GAIDynamicAgent(Agent):
 
     def update(self, reward: NDArray[1, Reward], action: NDArray[1, Action]):
         m = self.__a / (self.__a + self.__b)
-        mu = self.__alpha_t / (self.__alpha_t + self.__beta_t)
+        mu = self._alpha_t / (self._alpha_t + self._beta_t)
         eta = .5 * self.__omega / (.5 * self.__omega +
                                    (mu * reward + (1 - mu) *
                                     (1 - reward)) * (1 - self.__omega))
         self.__omega = m * (1 - eta)
-        alpha_t_new = (1 - eta) * self.__alpha_t \
+        alpha_t_new = (1 - eta) * self._alpha_t \
             + eta * self.__alpha_zero \
             + reward
-        self.__alpha_t += (alpha_t_new - self.__alpha_t) * action * self.__lr
-        beta_t_new = (1 - eta) * self.__beta_t \
+        self._alpha_t += (alpha_t_new - self._alpha_t) * action * self.__lr
+        beta_t_new = (1 - eta) * self._beta_t \
             + eta * self.__beta_zero \
             + (1 - reward)
-        self.__beta_t += (beta_t_new - self.__beta_t) * action * self.__lr
+        self._beta_t += (beta_t_new - self._beta_t) * action * self.__lr
         self.__a += self.__omega
         self.__b += 1 - eta - self.__omega
 
     def predict(self) -> Tuple[NDArray[1, Prediction], NDArray[1, Prediction]]:
-        nu_t = self.__alpha_t + self.__beta_t
-        mu_t = self.__alpha_t / nu_t
-        kl_div_a = -betaln(self.__alpha_t, self.__beta_t) \
-            + (self.__alpha_t - self.__alpha) * digamma(self.__alpha_t) \
-            + (self.__beta_t - 1) * digamma(self.__beta_t) \
+        nu_t = self._alpha_t + self._beta_t
+        mu_t = self._alpha_t / nu_t
+        kl_div_a = -betaln(self._alpha_t, self._beta_t) \
+            + (self._alpha_t - self.__alpha) * digamma(self._alpha_t) \
+            + (self._beta_t - 1) * digamma(self._beta_t) \
             + (self.__alpha + 1 - nu_t) * digamma(nu_t)
-        h_a = - mu_t * digamma(self.__alpha_t + 1) \
-            - (1 - mu_t) * digamma(self.__beta_t + 1) \
+        h_a = - mu_t * digamma(self._alpha_t + 1) \
+            - (1 - mu_t) * digamma(self._beta_t + 1) \
             + digamma(nu_t + 1)
         epistemic = \
-            mu_t * (-np.log(mu_t) + digamma(self.__alpha_t + 1) - digamma(nu_t + 1)) \
-            + (1 - mu_t) * (-np.log(1 - mu_t) + digamma(self.__beta_t + 1) - digamma(nu_t + 1))
+            mu_t * (-np.log(mu_t) + digamma(self._alpha_t + 1) - digamma(nu_t + 1)) \
+            + (1 - mu_t) * (-np.log(1 - mu_t) + digamma(self._beta_t + 1) - digamma(nu_t + 1))
         pragmatic = kl_div_a + h_a - epistemic
         return pragmatic, epistemic
 
@@ -215,11 +215,11 @@ class GAIDynamicAgent(Agent):
 
     @property
     def alpha_t(self) -> NDArray[1, float]:
-        return self.__alpha_t
+        return self._alpha_t
 
     @property
     def beta_t(self) -> NDArray[1, float]:
-        return self.__beta_t
+        return self._beta_t
 
     @property
     def k(self) -> int:
@@ -234,10 +234,10 @@ class SAIDynamicAgent(Agent):
     """
     def __init__(self, lamb: float, k: NumberOfOptions, lr: float):
         self.__lambda = lamb
-        self.__alpha_t: NDArray[1, float] = np.ones(k)
-        self.__alpha_zero = self.__alpha_t.copy()
-        self.__beta_t: NDArray[1, float] = np.ones(k)
-        self.__beta_zero = self.__beta_t.copy()
+        self._alpha_t: NDArray[1, float] = np.ones(k)
+        self.__alpha_zero = self._alpha_t.copy()
+        self._beta_t: NDArray[1, float] = np.ones(k)
+        self.__beta_zero = self._beta_t.copy()
         self.__a = np.full(k, 0.5)
         self.__b = np.full(k, 20.)
         self.__omega = np.zeros(k)
@@ -246,35 +246,35 @@ class SAIDynamicAgent(Agent):
 
     def update(self, reward: NDArray[1, Reward], action: NDArray[1, Action]):
         m = self.__a / (self.__a + self.__b)
-        mu = self.__alpha_t / (self.__alpha_t + self.__beta_t)
+        mu = self._alpha_t / (self._alpha_t + self._beta_t)
         eta = .5 * self.__omega / (.5 * self.__omega +
                                    (mu * reward + (1 - mu) *
                                     (1 - reward)) * (1 - self.__omega))
         self.__omega = m * (1 - eta)
-        alpha_t_new = (1 - eta) * self.__alpha_t \
+        alpha_t_new = (1 - eta) * self._alpha_t \
             + eta * self.__alpha_zero \
             + reward
-        self.__alpha_t += (alpha_t_new - self.__alpha_t) * action * self.__lr
-        beta_t_new = (1 - eta) * self.__beta_t \
+        self._alpha_t += (alpha_t_new - self._alpha_t) * action * self.__lr
+        beta_t_new = (1 - eta) * self._beta_t \
             + eta * self.__beta_zero \
             + (1 - reward)
-        self.__beta_t += (beta_t_new - self.__beta_t) * action * self.__lr
+        self._beta_t += (beta_t_new - self._beta_t) * action * self.__lr
         self.__a += self.__omega
         self.__b += 1 - eta - self.__omega
 
     def predict(self) -> Tuple[NDArray[1, Prediction], NDArray[1, Prediction]]:
-        nu_t = self.__alpha_t + self.__beta_t
-        mu_t = self.__alpha_t / nu_t
+        nu_t = self._alpha_t + self._beta_t
+        mu_t = self._alpha_t / nu_t
 
         kl_div_a = - self.__lambda * (2 * mu_t - 1) \
             + mu_t * np.log(mu_t) \
             + (1 - mu_t) * np.log(1 - mu_t)
-        h_a = - mu_t * digamma(self.__alpha_t + 1) \
-            - (1 - mu_t) * digamma(self.__beta_t + 1) \
+        h_a = - mu_t * digamma(self._alpha_t + 1) \
+            - (1 - mu_t) * digamma(self._beta_t + 1) \
             + digamma(nu_t + 1)
         epistemic = \
-            mu_t * (-np.log(mu_t) + digamma(self.__alpha_t + 1) - digamma(nu_t + 1)) \
-            + (1 - mu_t) * (-np.log(1 - mu_t) + digamma(self.__beta_t + 1) - digamma(nu_t + 1))
+            mu_t * (-np.log(mu_t) + digamma(self._alpha_t + 1) - digamma(nu_t + 1)) \
+            + (1 - mu_t) * (-np.log(1 - mu_t) + digamma(self._beta_t + 1) - digamma(nu_t + 1))
         pragmatic = kl_div_a + h_a - epistemic
         return pragmatic, epistemic
 
@@ -291,11 +291,11 @@ class SAIDynamicAgent(Agent):
 
     @property
     def alpha_t(self) -> NDArray[1, float]:
-        return self.__alpha_t
+        return self._alpha_t
 
     @property
     def beta_t(self) -> NDArray[1, float]:
-        return self.__beta_t
+        return self._beta_t
 
     @property
     def k(self) -> int:

--- a/aibes/schedule.py
+++ b/aibes/schedule.py
@@ -84,6 +84,8 @@ class VariableInterval(Schedule):
         self.__interval = self.__intervals[self.__count]
 
     def step(self, count: Interval, action: Action) -> int:
+        if self.finished():
+            return 0
         self.__interval -= count
         if self.__interval <= 0. and action == 1:
             self.__count += 1
@@ -145,6 +147,8 @@ class VariableRatio(Schedule):
         self.__response = self.__responses[self.__count]
 
     def step(self, count: Action, action: Action) -> int:
+        if self.finished():
+            return 0
         self.__response -= count
         if self.__response <= 0 and action == 1:
             self.__count += 1
@@ -242,6 +246,8 @@ class ConcurrentSchedule(Schedule):
             self.__schedules[i].config(val[i], n[i], _min[i])
 
     def step(self, count: Sequence, action: Sequence) -> NDArray[1, int]:
+        if self.finished():
+            return np.zeros(len(self.__schedules))
         rewards: NDArray[1, Reward] = np.zeros(len(self.__schedules))
         for i in range(len(self.__schedules)):
             rew = self.__schedules[i].step(count[i], action[i])

--- a/aibes/util.py
+++ b/aibes/util.py
@@ -1,8 +1,10 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, List
 
 import numpy as np
 from nptyping import NDArray
+
+from aibes.model import Agent
 
 
 def get_nth_ancestor(relpath: str, n: int) -> Path:
@@ -11,3 +13,12 @@ def get_nth_ancestor(relpath: str, n: int) -> Path:
 
 def randomize(v: NDArray[1, Any]) -> NDArray[1, Any]:
     return np.random.choice(v, size=len(v), replace=False)
+
+
+def colnames(agent: Agent, condition: str) -> List[str]:
+    k = agent.k
+    colnames = [condition, "reward", "action"]
+    colnames += [f"pragmatic_{i}" for i in range(k)]
+    colnames += [f"epistemic_{i}" for i in range(k)]
+    colnames += [f"response_probability_{i}" for i in range(k)]
+    return colnames

--- a/extbrst/compare_reward_rate.py
+++ b/extbrst/compare_reward_rate.py
@@ -1,13 +1,17 @@
-from typing import List, Tuple
+from typing import Tuple
 
 import numpy as np
+import pandas as pd
 from aibes.model import Action, Agent, Prediction, Probability, Reward
 from aibes.schedule import (ConcurrentSchedule, Extinction, VariableInterval,
                             VariableRatio)
 from aibes.types import (Duration, Interval, NumberOfOptions, NumberOfReward,
                          RequiredResponse)
+from aibes.util import colnames
+from nptyping import NDArray
 
-Result = Tuple[Action, Reward, Prediction, Probability]
+Result = Tuple[Action, Reward, NDArray[1, Prediction], NDArray[1, Prediction],
+               NDArray[1, Probability]]
 OutputData = Tuple[Probability, Action, Reward, Prediction, Probability]
 
 
@@ -23,13 +27,23 @@ def run_baseline(agent: Agent, schedule: ConcurrentSchedule,
         counts[1:] = [timestep for _ in range(len(counts) - 1)]
         rewards = schedule.step(counts, actions.tolist())
         agent.update(rewards, actions.astype(np.uint8))
-        ret = actions[0], rewards[0], preds[0], probs[0]
-        return ret
+        chosen_action: Action = np.argmax(actions)
+        reward: Reward = np.max(rewards)
+        return chosen_action, reward, pragmatic, epistemic, probs
 
-    results: List[Result] = []
+    ret_actions, ret_rewards = np.zeros(1), np.zeros(1)
+    ret_pragmatics, ret_epistemics = np.zeros(agent.k), np.zeros(agent.k)
+    ret_probs = np.zeros(agent.k)
     while not schedule.finished():
-        results.append(trial_process(agent, schedule, timestep))
-    return results
+        action, reward, pragmatics, epistemics, probs = \
+            trial_process(agent, schedule, timestep)
+        ret_actions = np.vstack((ret_actions, action))
+        ret_rewards = np.vstack((ret_rewards, reward))
+        ret_pragmatics = np.vstack((ret_pragmatics, pragmatics))
+        ret_epistemics = np.vstack((ret_epistemics, epistemics))
+        ret_probs = np.vstack((ret_probs, probs))
+    return np.hstack(
+        (ret_actions, ret_rewards, ret_pragmatics, ret_epistemics, ret_probs))
 
 
 def run_extinction(agent: Agent, schedule: ConcurrentSchedule,
@@ -44,59 +58,100 @@ def run_extinction(agent: Agent, schedule: ConcurrentSchedule,
         actions = agent.choose_action(probs)
         rewards = schedule.step(counts, actions.tolist())
         agent.update(rewards, actions.astype(np.uint8))
-        ret = actions[0], rewards[0], preds[0], probs[0]
-        return ret
+        chosen_action: Action = np.argmax(actions)
+        reward: Reward = np.max(rewards)
+        return chosen_action, reward, pragmatic, epistemic, probs
 
-    results: List[Result] = []
+    ret_actions, ret_rewards = np.zeros(1), np.zeros(1)
+    ret_pragmatics, ret_epistemics = np.zeros(agent.k), np.zeros(agent.k)
+    ret_probs = np.zeros(agent.k)
     while not schedule.finished():
-        results.append(trial_process(agent, schedule, timestep))
-    return results
+        action, reward, pragmatics, epistemics, probs = \
+            trial_process(agent, schedule, timestep)
+        ret_actions = np.vstack((ret_actions, action))
+        ret_rewards = np.vstack((ret_rewards, reward))
+        ret_pragmatics = np.vstack((ret_pragmatics, pragmatics))
+        ret_epistemics = np.vstack((ret_epistemics, epistemics))
+        ret_probs = np.vstack((ret_probs, probs))
+    return np.hstack(
+        (ret_actions, ret_rewards, ret_pragmatics, ret_epistemics, ret_probs))
 
 
 if __name__ == '__main__':
-    from aibes.model import GAIStaticAgent
+    import argparse as ap
+
+    from aibes.model import (GAIDynamicAgent, GAIStaticAgent, SAIDynamicAgent,
+                             SAIStaticAgent)
     from aibes.util import get_nth_ancestor
     from pandas import DataFrame
 
-    requirements: List[RequiredResponse] = [1 + 1e-8]
-    extinction: Probability = 0.
-    baseline_lenght: NumberOfReward = 500
-    extinction_lenght: Duration = 3600
-    num_alt: NumberOfOptions = 10
+    clap = ap.ArgumentParser(description="about this simulation")
+    clap.add_argument("--agent-type", "-A", type=str, default="GAIStaticAgent")
+    clap.add_argument("--requirement", "-r", type=float, default=1.)
+    clap.add_argument("--num-reward", "-R", type=int, default=300)
+    clap.add_argument("--num-alternatives", "-a", type=int, default=1)
+    clap.add_argument("--mean-interval", "-i", type=float, default=120.)
+    clap.add_argument("--extinction-duration", "-e", type=float, default=1200.)
+    clap.add_argument("--timestep", "-t", type=float, default=1.)
+    clap.add_argument("--learning-rate", "-l", type=float, default=.1)
+    clap.add_argument("--lamb", "-L", type=float, default=1.)
+    args = clap.parse_args()
 
-    results: List[List[OutputData]] = []
-    # run simulations for each VR schedule
-    for rq in requirements:
-        agent = GAIStaticAgent(1., 1 + num_alt, 0.1)
-        baseline_schedule = VariableRatio(rq, baseline_lenght, 0)
-        alternative_schedules = [
-            VariableInterval(120., 1000, 1.) for _ in range(num_alt)
-        ]
-        [s.forever() for s in alternative_schedules]
+    # TODO: make below variables are given as command line argument
+    requirement: RequiredResponse = args.requirement + 1e-8
+    num_rewards: NumberOfReward = args.num_reward
+    num_alts: NumberOfOptions = args.num_alternatives
+    mean_interval = args.mean_interval
+    extinction_duration: Duration = args.extinction_duration
+    timestep = args.timestep
+    lr = args.learning_rate
+    lamb = args.lamb
+    agent_type = args.agent_type
 
-        baseline_schedules = ConcurrentSchedule([baseline_schedule] +
-                                                alternative_schedules)
-        _baseline_result = run_baseline(agent, baseline_schedules, 1.)
+    if agent_type == "GAIStaticAgent":
+        AgentClass = GAIStaticAgent
+    elif agent_type == "GAIDynamicAgent":
+        AgentClass = GAIDynamicAgent
+    elif agent_type == "SAIStaticAgent":
+        AgentClass = SAIStaticAgent
+    elif agent_type == "SAIStaticAgent":
+        AgentClass = SAIDynamicAgent
+    else:
+        print(
+            f"""{agent_type} does not exists.\nAvailbele arguments are `GAIDynamicAgent`, `GAIDynamicAgent`, `SAIStaticAgent`, and `SAIDynamicAgent`)"""
+        )
+        exit()
+    agent = AgentClass(lamb, 1 + num_alts, lr)
 
-        ext = Extinction(extinction_lenght)
-        [alt.reset for alt in alternative_schedules]
-        extinction_schedules = ConcurrentSchedule([ext] +
-                                                  alternative_schedules)
-        _ext_result = run_extinction(agent, extinction_schedules, 1.)
-        baseline_result: List[OutputData] = \
-            list(map(lambda br: (1 / rq, ) + br, _baseline_result))
-        ext_result: List[OutputData] = \
-            list(map(lambda er: (extinction, ) + er, _ext_result))
-        results.append(baseline_result + ext_result)
+    target_schedule = VariableRatio(requirement, num_rewards, 0)
+    alternative_schedules = [
+        VariableInterval(mean_interval, 1000, timestep)
+        for _ in range(num_alts)
+    ]
+    [s.forever() for s in alternative_schedules]
 
-    data_dir = get_nth_ancestor(__file__, 1).joinpath("data")
+    baseline_schedules = ConcurrentSchedule([target_schedule] +
+                                            alternative_schedules)
+    baseline_result = run_baseline(agent, baseline_schedules, 1.)
+    nrow, _ = baseline_result.shape
+    reward_probs = np.full((nrow, 1), 1 / requirement)
+
+    target_schedules = Extinction(extinction_duration)
+    [alt.reset for alt in alternative_schedules]
+    extinction_schedules = ConcurrentSchedule([target_schedules] +
+                                              alternative_schedules)
+    ext_result = run_extinction(agent, extinction_schedules, 1.)
+    nrow, _ = ext_result.shape
+    reward_probs = np.vstack((reward_probs, np.full((nrow, 1), 0.)))
+
+    data_dir = get_nth_ancestor(__file__, 0).joinpath("data")
     if not data_dir.exists():
         data_dir.mkdir()
-    filename = data_dir.joinpath("compare_reward_rate.csv")
+    filename = data_dir.joinpath(
+        f"{agent_type}_lr-{lr}_lambda-{lamb}_VR-{int(requirement)}_nrewards-{num_rewards}_nalts-{num_alts}_VI-{mean_interval}.csv"
+    )
 
-    # `sum` can flatten list of list (f: List[List[T]] => List[T])
-    merged_result = sum(results, [])
-    df = DataFrame(
-        merged_result,
-        columns=["reward_prob", "action", "reward", "G", "action_prob"])
-    df.to_csv(filename, index=False)
+    merged_result = np.vstack((baseline_result, ext_result))
+    output_data = pd.DataFrame(np.hstack((reward_probs, merged_result)),
+                               columns=colnames(agent, "reward_probability"))
+    output_data.to_csv(filename, index=False)

--- a/extbrst/compare_reward_rate.py
+++ b/extbrst/compare_reward_rate.py
@@ -97,7 +97,6 @@ if __name__ == '__main__':
     clap.add_argument("--lamb", "-L", type=float, default=1.)
     args = clap.parse_args()
 
-    # TODO: make below variables are given as command line argument
     requirement: RequiredResponse = args.requirement + 1e-8
     num_rewards: NumberOfReward = args.num_reward
     num_alts: NumberOfOptions = args.num_alternatives

--- a/extbrst/compare_reward_rate.py
+++ b/extbrst/compare_reward_rate.py
@@ -15,7 +15,8 @@ def run_baseline(agent: Agent, schedule: ConcurrentSchedule,
                  timestep: Interval):
     def trial_process(agent: Agent, schedule: ConcurrentSchedule,
                       timestep: float) -> Result:
-        preds = agent.predict()
+        pragmatic, epistemic = agent.predict()
+        preds = pragmatic + epistemic
         probs = agent.calculate_response_probs(-preds)
         actions = agent.choose_action(probs)
         counts = actions.copy().tolist()
@@ -37,7 +38,8 @@ def run_extinction(agent: Agent, schedule: ConcurrentSchedule,
 
     def trial_process(agent: Agent, schedule: ConcurrentSchedule,
                       timestep: Interval) -> Result:
-        preds = agent.predict()
+        pragmatic, epistemic = agent.predict()
+        preds = pragmatic + epistemic
         probs = agent.calculate_response_probs(-preds)
         actions = agent.choose_action(probs)
         rewards = schedule.step(counts, actions.tolist())

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,132 @@
+import aibes.model as m
+import numpy as np
+import pytest
+
+AGENT_CLASSES = [
+    m.GAIStaticAgent, m.SAIStaticAgent, m.GAIDynamicAgent, m.SAIDynamicAgent
+]
+GAIAGENT_CLASSES = [m.GAIStaticAgent, m.GAIDynamicAgent]
+SAIAGENT_CLASSES = [m.SAIStaticAgent, m.SAIDynamicAgent]
+
+
+@pytest.mark.parametrize("k, expected", [(1, np.ones(1)), (2, np.ones(2)),
+                                         (3, np.ones(3)), (100, np.ones(100))])
+def test_model_initialize(k, expected):
+    for ac in AGENT_CLASSES:
+        agent = ac(1., k, 0.1)
+        agent = m.GAIStaticAgent(1., k, 0.1)
+        assert sum(agent._alpha_t == expected)
+        assert sum(agent.beta_t == expected)
+
+
+@pytest.mark.parametrize(
+    "rewards, actions, lr, expected_alpha, expected_beta", [
+        (np.zeros(2), np.zeros(2), 0.1, np.ones(2), np.ones(2)),
+        (np.zeros(2), np.ones(2), 0.1, np.ones(2), np.full(2, 1.1)),
+        (np.ones(2), np.ones(2), 0.1, np.full(2, 1.1), np.ones(2)),
+        (np.ones(2), np.zeros(2), 0.1, np.ones(2), np.ones(2)),
+        (np.ones(2), np.ones(2), 0.2, np.full(2, 1.2), np.ones(2)),
+        (np.array([1, 0]), np.ones(2), 0.1, np.array([1.1, 1
+                                                      ]), np.array([1., 1.1])),
+        (np.array([1, 0]), np.ones(2), 0.2, np.array([1.2, 1
+                                                      ]), np.array([1., 1.2])),
+        (np.array([0, 1]), np.ones(2), 0.1, np.array([1., 1.1
+                                                      ]), np.array([1.1, 1.])),
+        (np.array([0, 1]), np.ones(2), 0.2, np.array([1., 1.2
+                                                      ]), np.array([1.2, 1.])),
+    ])
+def test_update(rewards, actions, lr, expected_alpha, expected_beta):
+    k = 2
+    for ac in AGENT_CLASSES:
+        agent: m.Agent = ac(1., k, lr)
+        agent.update(rewards, actions)
+        assert sum(agent.alpha_t == expected_alpha) == k
+        assert sum(agent.beta_t == expected_beta) == k
+
+
+def G(alpha_t, beta_t, alpha):
+    """
+    Original implemation by Markovic (https://github.com/dimarkov/aibandits/blob/master/choice_algos.py)
+    """
+    from scipy.special import betaln, digamma
+    nu_t = alpha_t + beta_t
+    mu_t = alpha_t / nu_t
+
+    KL_a = - betaln(alpha_t, beta_t) + (alpha_t - alpha) * digamma(alpha_t)\
+             + (beta_t - 1) * digamma(beta_t) + (alpha + 1 - nu_t) * digamma(nu_t)
+    H_a = -mu_t * digamma(alpha_t + 1) - (
+        1 - mu_t) * digamma(beta_t + 1) + digamma(nu_t + 1)
+
+    return KL_a + H_a
+
+
+@pytest.mark.parametrize("alpha_t, beta_t, expected", [
+    (np.array([1, 1]), np.array(
+        [1, 1]), G(np.array([1, 1]), np.array([1, 1]), np.exp(2))),
+    (np.array([2, 1]), np.array(
+        [1, 1]), G(np.array([2, 1]), np.array([1, 1]), np.exp(2))),
+    (np.array([1, 2]), np.array(
+        [1, 1]), G(np.array([1, 2]), np.array([1, 1]), np.exp(2))),
+    (np.array([1, 1]), np.array(
+        [2, 1]), G(np.array([1, 1]), np.array([2, 1]), np.exp(2))),
+    (np.array([1, 1]), np.array(
+        [1, 2]), G(np.array([1, 1]), np.array([1, 2]), np.exp(2))),
+    (np.array([2, 2]), np.array(
+        [2, 2]), G(np.array([2, 2]), np.array([2, 2]), np.exp(2))),
+    (np.array([100, 100]), np.array(
+        [100, 100]), G(np.array([100, 100]), np.array([100, 100]), np.exp(2))),
+])
+def test_predict_gaia(alpha_t, beta_t, expected):
+    k = 2
+    lr = 0.1
+    for ac in GAIAGENT_CLASSES:
+        agent: m.Agent = ac(1., k, lr)
+        agent._alpha_t = alpha_t
+        agent._beta_t = beta_t
+        pragmatic, epistemic = agent.predict()
+        preds = pragmatic + epistemic
+        assert sum(preds == expected) == 2
+
+
+def S(alpha_t, beta_t, lam):
+    """
+    Original implemation by Markovic (https://github.com/dimarkov/aibandits/blob/master/choice_algos.py)
+    """
+    from scipy.special import digamma
+    nu_t = alpha_t + beta_t
+    mu_t = alpha_t / nu_t
+
+    KL_a = -lam * (2 * mu_t -
+                   1) + mu_t * np.log(mu_t) + (1 - mu_t) * np.log(1 - mu_t)
+    H_a = -mu_t * digamma(alpha_t + 1) - (
+        1 - mu_t) * digamma(beta_t + 1) + digamma(nu_t + 1)
+
+    return KL_a + H_a
+
+
+@pytest.mark.parametrize("alpha_t, beta_t, expected", [
+    (np.array([1, 1]), np.array(
+        [1, 1]), S(np.array([1, 1]), np.array([1, 1]), 1.)),
+    (np.array([2, 1]), np.array(
+        [1, 1]), S(np.array([2, 1]), np.array([1, 1]), 1.)),
+    (np.array([1, 2]), np.array(
+        [1, 1]), S(np.array([1, 2]), np.array([1, 1]), 1.)),
+    (np.array([1, 1]), np.array(
+        [2, 1]), S(np.array([1, 1]), np.array([2, 1]), 1.)),
+    (np.array([1, 1]), np.array(
+        [1, 2]), S(np.array([1, 1]), np.array([1, 2]), 1.)),
+    (np.array([2, 2]), np.array(
+        [2, 2]), S(np.array([2, 2]), np.array([2, 2]), 1.)),
+    (np.array([100, 100]), np.array(
+        [100, 100]), S(np.array([100, 100]), np.array([100, 100]), 1.)),
+])
+def test_predict_saia(alpha_t, beta_t, expected):
+    k = 2
+    lr = 0.1
+    for ac in SAIAGENT_CLASSES:
+        agent: m.Agent = ac(1., k, lr)
+        agent._alpha_t = alpha_t
+        agent._beta_t = beta_t
+        pragmatic, epistemic = agent.predict()
+        preds = pragmatic + epistemic
+        assert sum(preds == expected) == 2

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,199 @@
+from typing import List, Tuple
+
+import aibes.schedule as s
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("ratio, n", [(5., 100), (10., 100), (100., 100),
+                                      (5., 1000), (5., 10000)])
+def test_vr_initialize(ratio: float, n: int):
+    _min = 0
+    vr = s.VariableRatio(ratio, n, _min)
+    unexpected = s._geom_rng(ratio, n, _min)
+    assert not np.array_equal(vr.vals, unexpected)
+    vr.vals.sort()
+    assert np.array_equal(vr.vals, unexpected)
+
+
+@pytest.mark.parametrize("interval, n", [(5., 100), (10., 100), (100., 100),
+                                         (5., 1000), (5., 10000)])
+def test_vi_initialize(interval: float, n: int):
+    _min = 0
+    vi = s.VariableInterval(interval, n, _min)
+    unexpected = s._exp_rng(interval, n, _min)
+    assert not np.array_equal(vi.vals, unexpected)
+    vi.vals.sort()
+    assert np.array_equal(vi.vals, unexpected)
+
+
+@pytest.mark.parametrize("interval, timestep", [
+    (1., .01),
+    (1., .1),
+    (1., .5),
+    (1., 1.),
+    (10., .01),
+    (10., .1),
+    (10., .5),
+    (10., 1.),
+    (100., .01),
+    (100., .1),
+    (100., .5),
+    (100., 1.),
+])
+def test_vi_step(interval, timestep: float):
+    vi = s.VariableInterval(interval, 10, 1.)
+    intervals = vi.vals
+    expected_rewards: List[int] = []
+    observed_rewards: List[int] = []
+    for interval in intervals:
+        while True:
+            action = int(np.random.uniform() < 0.9)
+            interval -= timestep
+            observed = vi.step(timestep, action)
+            observed_rewards.append(observed)
+            if action and interval <= 0.:
+                expected_rewards.append(1)
+                break
+            else:
+                expected_rewards.append(0)
+    assert expected_rewards == observed_rewards
+    assert vi.finished()
+    assert vi.step(timestep, 1) == 0
+
+
+@pytest.mark.parametrize("req", [1., 10., 100.])
+def test_vr_step(req):
+    vr = s.VariableRatio(req, 10, 0.)
+    required_responses = vr.vals
+    expected_rewards: List[int] = []
+    observed_rewards: List[int] = []
+    for req in required_responses:
+        while True:
+            action = int(np.random.uniform() < 0.9)
+            req -= action
+            observed = vr.step(action, action)
+            observed_rewards.append(observed)
+            if action and req <= 0.:
+                expected_rewards.append(1)
+                break
+            else:
+                expected_rewards.append(0)
+    assert expected_rewards == observed_rewards
+    assert vr.finished()
+    assert vr.step(1, 1) == 0
+
+
+@pytest.mark.parametrize("interval, timestep, num_reward", [
+    (10., .1, 20),
+    (10., .1, 30),
+    (10., .1, 21),
+    (10., .1, 29),
+])
+def test_vi_forever(interval, timestep: float, num_reward: int):
+    vi = s.VariableInterval(interval, 10, 1.)
+    vi.forever()
+    expected_rewards: List[int] = []
+    observed_rewards: List[int] = []
+    cumulative_rewards = 0
+    while cumulative_rewards < num_reward:
+        intervals = vi.vals
+        for interval in intervals:
+            while True:
+                action = int(np.random.uniform() < 0.9)
+                interval -= timestep
+                observed = vi.step(timestep, action)
+                observed_rewards.append(observed)
+                if action and interval <= 0.:
+                    expected_rewards.append(1)
+                    cumulative_rewards += 1
+                    break
+                else:
+                    expected_rewards.append(0)
+            if cumulative_rewards >= num_reward:
+                break
+    assert expected_rewards == observed_rewards
+    assert cumulative_rewards == num_reward
+
+
+@pytest.mark.parametrize("req, num_reward", [(10., 20), (10., 30), (10., 21),
+                                             (10., 29)])
+def test_vr_forever(req, num_reward):
+    vr = s.VariableRatio(req, 10, 0.)
+    vr.forever()
+    expected_rewards: List[int] = []
+    observed_rewards: List[int] = []
+    cumulative_rewards = 0
+    while cumulative_rewards < num_reward:
+        required_responses = vr.vals
+        for req in required_responses:
+            while True:
+                action = int(np.random.uniform() < 0.9)
+                req -= action
+                observed = vr.step(action, action)
+                observed_rewards.append(observed)
+                if action and req <= 0.:
+                    expected_rewards.append(1)
+                    cumulative_rewards += 1
+                    break
+                else:
+                    expected_rewards.append(0)
+            if cumulative_rewards >= num_reward:
+                break
+    assert expected_rewards == observed_rewards
+    assert cumulative_rewards == num_reward
+
+
+@pytest.mark.parametrize("n", [1, 10, 100])
+def test_conc_step(n):
+    vi = s.VariableInterval(10., n, 1.)
+    vr = s.VariableRatio(10, n, 0.)
+    conc = s.ConcurrentSchedule([vi, vr])
+
+    cumulative_rewards_vi = 0
+    cumulative_rewards_vr = 0
+
+    intervals = vi.vals
+    required_responses = vr.vals
+    interval = intervals[cumulative_rewards_vi]
+    req = required_responses[cumulative_rewards_vr]
+
+    expected_rewards: List[Tuple[int, int]] = []
+    observed_rewards: List[Tuple[int, int]] = []
+
+    while not conc.finished():
+        while True:
+            if np.random.uniform() <= 0.5:
+                actions = np.array([1, 0])
+            else:
+                actions = np.array([0, 1])
+
+            counts = actions.copy()
+            counts[0] = 1.
+
+            interval -= 1.
+            req -= actions[1]
+            obs = conc.step(counts.tolist(), actions.tolist())
+
+            if actions[0] == 1 and interval <= 0.:
+                exp0 = 1
+                cumulative_rewards_vi += 1
+                if not cumulative_rewards_vi == n:
+                    interval = intervals[cumulative_rewards_vi]
+            else:
+                exp0 = 0
+
+            if actions[1] == 1 and req <= 0.:
+                exp1 = 1
+                cumulative_rewards_vr += 1
+                if not n == cumulative_rewards_vr:
+                    req = required_responses[cumulative_rewards_vr]
+            else:
+                exp1 = 0
+
+            expected_rewards.append((exp0, exp1))
+            observed_rewards.append((obs[0], obs[1]))
+            if exp0 == 1 or exp1 == 1:
+                break
+
+    assert expected_rewards == observed_rewards


### PR DESCRIPTION
This PR contains two changes. First, add unit tests for `schedule.py` and `model.py` to validate `class` and their methods behavior. Second, enable to pass model and experimental parameters from the command line to run simulations under various conditions.